### PR TITLE
Add url to Google/Apple contact tracing API specs

### DIFF
--- a/product-definitie.md
+++ b/product-definitie.md
@@ -7,7 +7,7 @@ In aanvulling op het **analoge contactonderzoek**, bieden wij **de mogelijkheid 
 
 ### Wat doet de app?
 
-De app maakt gebruik van de Google/Apple Exposure Notification API. Die houdt via Bluetooth Low Energy bij welke andere telefoons bij jou in de nabijheid zijn. Dat gebeurt anoniem en veilig.
+De app maakt gebruik van de [Google/Apple Exposure Notification API](https://www.apple.com/covid19/contacttracing). Die houdt via Bluetooth Low Energy bij welke andere telefoons bij jou in de nabijheid zijn. Dat gebeurt anoniem en veilig.
 
 De app waarschuwt de eigenaar als die in de afgelopen 14 dagen in de buurt is geweest van een app-gebruiker die in de dagen na die ontmoeting positief getest is op COVID-19 en tijdens de ontmoeting mogelijk al besmettelijk was.
 

--- a/product-definitie.md
+++ b/product-definitie.md
@@ -7,7 +7,7 @@ In aanvulling op het **analoge contactonderzoek**, bieden wij **de mogelijkheid 
 
 ### Wat doet de app?
 
-De app maakt gebruik van de [Google/Apple Exposure Notification API](https://www.apple.com/covid19/contacttracing). Die houdt via Bluetooth Low Energy bij welke andere telefoons bij jou in de nabijheid zijn. Dat gebeurt anoniem en veilig.
+De app maakt gebruik van de [Google](https://www.google.com/covid19/exposurenotifications/)/[Apple](https://www.apple.com/covid19/contacttracing) Exposure Notification API. Die houdt via Bluetooth Low Energy bij welke andere telefoons bij jou in de nabijheid zijn. Dat gebeurt anoniem en veilig.
 
 De app waarschuwt de eigenaar als die in de afgelopen 14 dagen in de buurt is geweest van een app-gebruiker die in de dagen na die ontmoeting positief getest is op COVID-19 en tijdens de ontmoeting mogelijk al besmettelijk was.
 


### PR DESCRIPTION
Zoals in deze issue blijkt: https://github.com/minvws/nl-covid19-notification-app-design/issues/11

Hebben mensen vragen over de details van de API die gebruikt wordt. De suggestie is om een link naar de API details aan de documentatie toe te voegen. 